### PR TITLE
handleCheckOrFix: test fpCheckFile for NULL

### DIFF
--- a/EccEdc/EccEdc.cpp
+++ b/EccEdc/EccEdc.cpp
@@ -759,7 +759,7 @@ INT handleCheckOrFix(
 	UINT nSecuROMSector = 0;
 
 	if (!strncmp(pszType, "TOC", 3)) {
-		if (fread(&tocbuf, sizeof(BYTE), sizeof(tocbuf), fpCheckFile) < sizeof(tocbuf)) {
+		if (!fpCheckFile || fread(&tocbuf, sizeof(BYTE), sizeof(tocbuf), fpCheckFile) < sizeof(tocbuf)) {
 			OutputErrorString("Failed to read [F:%s][L:%d]\n", __FUNCTION__, __LINE__);
 			return EXIT_FAILURE;
 		}


### PR DESCRIPTION
It is possible for fpCheckFile to be NULL if the earlier call to fopen fails. This resolves a segmentation fault in this scenario.